### PR TITLE
feat: add dynamic OpenGraph image for search results

### DIFF
--- a/src/app/api/og/search/route.tsx
+++ b/src/app/api/og/search/route.tsx
@@ -1,0 +1,209 @@
+import { ImageResponse } from "@vercel/og";
+import type { NextRequest } from "next/server";
+
+export const runtime = "edge";
+
+export async function GET(req: NextRequest) {
+	const { searchParams } = new URL(req.url);
+	const query = searchParams.get("q") || "developers";
+
+	return new ImageResponse(
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				flexDirection: "column",
+				alignItems: "center",
+				justifyContent: "center",
+				backgroundColor: "var(--background)",
+				color: "#ffffff",
+				position: "relative",
+				overflow: "hidden",
+			}}
+		>
+			<div
+				style={{
+					position: "absolute",
+					width: "600px",
+					height: "600px",
+					borderRadius: "50%",
+					background:
+						"radial-gradient(circle, rgba(0, 128, 128, 0.089) 0%, rgba(0,128,128,0) 70%)",
+					bottom: "-200px",
+					left: "-100px",
+					display: "block",
+				}}
+			/>
+			<div
+				style={{
+					position: "absolute",
+					width: "500px",
+					height: "500px",
+					borderRadius: "50%",
+					background:
+						"radial-gradient(circle, rgba(18, 148, 68, 0.103) 0%, rgba(0,128,128,0) 70%)",
+					top: "-100px",
+					right: "-50px",
+					zIndex: 1,
+					display: "block",
+				}}
+			/>
+
+			{/* Content container */}
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "column",
+					alignItems: "center",
+					justifyContent: "center",
+					width: "90%",
+					maxWidth: "1000px",
+					padding: "60px 40px",
+				}}
+			>
+				{/* Logo and brand */}
+				<div
+					style={{
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						marginBottom: 36,
+						gap: 16,
+					}}
+				>
+					<div
+						style={{
+							width: 56,
+							height: 56,
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+						}}
+					>
+						<svg
+							width="43"
+							height="45"
+							viewBox="0 0 334 355"
+							fill="none"
+							aria-label="GitHunter logo"
+							aria-hidden="true"
+							focusable="false"
+						>
+							<path
+								d="M34.2282 1.13925C31.1183 2.55282 29.422 6.45429 26.9907 17.876C21.9018 41.9633 22.6934 66.0506 29.1959 86.1233L31.0618 91.8907L29.422 94.3221C4.93892 130.679 -4.05141 172.351 3.29917 215.72C13.4204 275.995 57.0715 326.544 115.48 345.825C152.007 357.869 192.322 356.738 228.001 342.602C278.833 322.53 316.434 279.387 329.552 226.237C333.171 211.479 333.962 204.468 333.962 186.657C333.962 173.086 333.793 169.637 332.718 162.626C331.135 152.392 327.799 139.5 324.35 130.001C320.958 120.841 313.777 106.592 308.405 98.3366L304.221 92.0038L305.691 87.7631C310.441 74.0797 312.702 56.721 311.685 41.6806C310.836 29.2411 307.105 9.62069 304.617 4.87108C302.016 -0.104699 297.945 -0.330871 286.24 3.85331C270.352 9.62069 248.865 22.6256 235.295 34.8389L232.129 37.666L226.078 35.4043C204.705 27.4883 190.23 24.9438 167.217 25.0004C150.367 25.0004 142.225 25.9051 128.711 29.1846C122.209 30.8243 109.656 34.7823 105.19 36.7048L103.098 37.6095L100.666 35.2912C86.8697 22.3429 64.0829 8.77255 46.1587 2.72245C39.5432 0.517273 36.5464 0.121472 34.2282 1.13925ZM185.594 67.9165C234.39 75.2105 275.158 111.681 287.032 158.555C289.859 169.524 290.424 174.557 290.424 187.788C290.481 201.528 289.802 207.295 286.862 218.773C277.533 254.904 251.014 286.116 217.088 300.987C166.595 323.038 106.264 308.507 71.3769 265.817C59.3333 251.116 49.4382 230.195 45.9891 212.271C39.0343 176.253 48.3639 139.613 71.49 112.02C93.0894 86.2364 122.718 70.574 156.757 67.0684C163.259 66.3898 178.3 66.8422 185.594 67.9165Z"
+								fill="white"
+							/>
+							<path
+								d="M220.65 111.342C219.519 111.737 215.335 114.225 211.321 116.77C207.25 119.371 197.863 125.364 190.4 130.114C182.936 134.807 171.345 142.214 164.673 146.511C158.001 150.809 149.463 156.067 145.787 158.159C142.056 160.308 138.606 162.456 138.041 162.965C135.383 165.397 109.204 222.279 98.9698 247.949C95.5772 256.544 95.7468 260.502 99.5918 264.008C102.306 266.439 105.416 267.117 108.299 265.873C111.07 264.743 122.322 257.901 133.291 250.72C138.267 247.44 150.876 239.355 161.28 232.739C183.841 218.377 191.078 213.571 192.775 211.762C194.358 210.009 203.065 192.481 216.127 164.888C221.781 152.901 228.51 139.104 230.998 134.241C235.238 126.043 235.634 125.081 235.578 122.085C235.578 119.823 235.182 118.07 234.334 116.43C232.015 112.02 225.4 109.532 220.65 111.342Z"
+								fill="white"
+							/>
+						</svg>
+					</div>
+					<h1
+						style={{
+							fontSize: 48,
+							fontWeight: 800,
+							margin: 0,
+							color: "#ffffff",
+						}}
+					>
+						GitHunter
+					</h1>
+				</div>
+
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "column",
+						alignItems: "center",
+						gap: 8,
+						marginBottom: 40,
+					}}
+				>
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							marginTop: 12,
+							marginBottom: 24,
+							fontSize: 32,
+							fontWeight: 400,
+							color: "#94a3b8",
+							padding: "8px 16px",
+							borderRadius: "20px",
+							background: "rgba(255,255,255,0.06)",
+							border: "1px solid rgba(255,255,255,0.1)",
+						}}
+					>
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							width="26"
+							height="26"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-label="Search icon"
+							aria-hidden="true"
+							focusable="false"
+							style={{
+								marginRight: 8,
+							}}
+						>
+							<path d="m21 21-4.34-4.34" />
+							<circle cx="11" cy="11" r="8" />
+						</svg>
+						Results for{" "}
+						<span style={{ fontWeight: 600, marginLeft: 6, color: "#ffffff" }}>
+							'{query}'
+						</span>
+					</div>
+				</div>
+			</div>
+			<div
+				style={{
+					position: "absolute",
+					bottom: 30,
+					width: "100%",
+					textAlign: "center",
+					fontSize: 18,
+					fontWeight: 500,
+					letterSpacing: "0.5px",
+					color: "#94a3b8",
+					display: "flex",
+					justifyContent: "center",
+					alignItems: "center",
+					gap: 8,
+				}}
+			>
+				<span
+					style={{
+						display: "block",
+						height: "1px",
+						width: "40px",
+						background:
+							"linear-gradient(90deg, rgba(148,163,184,0) 0%, rgba(148,163,184,0.5) 100%)",
+					}}
+				/>
+				Find the perfect developer for your project
+				<span
+					style={{
+						display: "block",
+						height: "1px",
+						width: "40px",
+						background:
+							"linear-gradient(90deg, rgba(148,163,184,0.5) 0%, rgba(148,163,184,0) 100%)",
+					}}
+				/>
+			</div>
+		</div>,
+		{
+			width: 1200,
+			height: 630,
+		},
+	);
+}

--- a/src/app/search/[slug]/page.tsx
+++ b/src/app/search/[slug]/page.tsx
@@ -25,6 +25,7 @@ import {
 	Users,
 	Wrench,
 } from "lucide-react";
+import type { Metadata } from "next";
 import Link from "next/link";
 import { getQueryParams } from "./get-query-params";
 import { queryUsers } from "./query-users";
@@ -390,4 +391,38 @@ export default async function SearchPage({
 			<Footer />
 		</div>
 	);
+}
+
+export async function generateMetadata({
+	params,
+}: {
+	params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+	const { slug } = await params;
+	const formattedQuery = slug.replace(/-/g, " ");
+
+	const title = `${formattedQuery} | GitHunter`;
+	const description =
+		"Find top GitHub developers. Discover talented programmers, view stats, repositories and more.";
+	const ogImageUrl = `/api/og/search?q=${encodeURIComponent(formattedQuery)}`;
+
+	return {
+		title,
+		description,
+		openGraph: {
+			title,
+			description,
+			images: [ogImageUrl],
+			url: `/search/${slug}`,
+			siteName: "GitHunter",
+			type: "website",
+		},
+		twitter: {
+			card: "summary_large_image",
+			title,
+			description,
+			images: [`${ogImageUrl}/opengraph-image`],
+		},
+		keywords: formattedQuery.split(" ").filter(Boolean),
+	};
 }


### PR DESCRIPTION
- Implemented a new API endpoint at `/api/og/search/route.tsx`
- Created a design with GitHunter branding and search query highlights
- Added proper metadata configuration for search pages