### PR TITLE
feat: add curriculum vitae field

### DIFF
--- a/drizzle/0009_add_curriculum_vitae_into_users.sql
+++ b/drizzle/0009_add_curriculum_vitae_into_users.sql
@@ -1,0 +1,5 @@
+-- ✨ UP
+ALTER TABLE "user" ADD COLUMN "curriculum_vitae" jsonb DEFAULT '{}'::jsonb NOT NULL;--> statement-breakpoint
+
+-- 🔄 DOWN
+ALTER TABLE "user" DROP COLUMN "curriculum_vitae";

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,651 @@
+{
+	"id": "ad046825-f30f-407e-b937-40eaf111d18a",
+	"prevId": "55fd8ec1-4f22-4c46-8bc6-cbd5e77a97e1",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"clerk_id": {
+					"name": "clerk_id",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"username": {
+					"name": "username",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fullname": {
+					"name": "fullname",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avatar_url": {
+					"name": "avatar_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stars": {
+					"name": "stars",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"followers": {
+					"name": "followers",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"following": {
+					"name": "following",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"repositories": {
+					"name": "repositories",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"contributions": {
+					"name": "contributions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"city": {
+					"name": "city",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"website": {
+					"name": "website",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"twitter": {
+					"name": "twitter",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"linkedin": {
+					"name": "linkedin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"about": {
+					"name": "about",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stack": {
+					"name": "stack",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ARRAY[]::text[]"
+				},
+				"potential_roles": {
+					"name": "potential_roles",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ARRAY[]::text[]"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"repos": {
+					"name": "repos",
+					"type": "jsonb[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'"
+				},
+				"pinned_repos": {
+					"name": "pinned_repos",
+					"type": "jsonb[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'"
+				},
+				"curriculum_vitae": {
+					"name": "curriculum_vitae",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				}
+			},
+			"indexes": {
+				"roles_idx": {
+					"name": "roles_idx",
+					"columns": [
+						{
+							"expression": "potential_roles",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"stack_idx": {
+					"name": "stack_idx",
+					"columns": [
+						{
+							"expression": "stack",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"city_idx": {
+					"name": "city_idx",
+					"columns": [
+						{
+							"expression": "city",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"country_idx": {
+					"name": "country_idx",
+					"columns": [
+						{
+							"expression": "country",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"contributions_idx": {
+					"name": "contributions_idx",
+					"columns": [
+						{
+							"expression": "contributions",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"roles_only_gin_idx": {
+					"name": "roles_only_gin_idx",
+					"columns": [
+						{
+							"expression": "potential_roles",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"stack_only_gin_idx": {
+					"name": "stack_only_gin_idx",
+					"columns": [
+						{
+							"expression": "stack",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"city_country_idx": {
+					"name": "city_country_idx",
+					"columns": [
+						{
+							"expression": "city",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "country",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"repos_gin_idx": {
+					"name": "repos_gin_idx",
+					"columns": [
+						{
+							"expression": "repos",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"username_idx": {
+					"name": "username_idx",
+					"columns": [
+						{
+							"expression": "username",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"stars_idx": {
+					"name": "stars_idx",
+					"columns": [
+						{
+							"expression": "stars",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"followers_idx": {
+					"name": "followers_idx",
+					"columns": [
+						{
+							"expression": "followers",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"repositories_idx": {
+					"name": "repositories_idx",
+					"columns": [
+						{
+							"expression": "repositories",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"stars_contributions_idx": {
+					"name": "stars_contributions_idx",
+					"columns": [
+						{
+							"expression": "stars",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "contributions",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"followers_stars_idx": {
+					"name": "followers_stars_idx",
+					"columns": [
+						{
+							"expression": "followers",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "stars",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_idx": {
+					"name": "email_idx",
+					"columns": [
+						{
+							"expression": "email",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_clerk_id_unique": {
+					"name": "user_clerk_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["clerk_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.subscription_plan": {
+			"name": "subscription_plan",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"currency": {
+					"name": "currency",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"amount": {
+					"name": "amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"polar_product_id": {
+					"name": "polar_product_id",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"polar_price_id": {
+					"name": "polar_price_id",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_sandbox": {
+					"name": "is_sandbox",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {
+				"subscription_plan_product_idx": {
+					"name": "subscription_plan_product_idx",
+					"columns": [
+						{
+							"expression": "polar_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"subscription_plan_price_idx": {
+					"name": "subscription_plan_price_idx",
+					"columns": [
+						{
+							"expression": "polar_price_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"subscription_plan_sandbox_idx": {
+					"name": "subscription_plan_sandbox_idx",
+					"columns": [
+						{
+							"expression": "is_sandbox",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_subscription": {
+			"name": "user_subscription",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"polar_customer_id": {
+					"name": "polar_customer_id",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"polar_product_id": {
+					"name": "polar_product_id",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"subscription_plan_id": {
+					"name": "subscription_plan_id",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"active": {
+					"name": "active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				}
+			},
+			"indexes": {
+				"user_subscription_user_idx": {
+					"name": "user_subscription_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"user_subscription_plan_idx": {
+					"name": "user_subscription_plan_idx",
+					"columns": [
+						{
+							"expression": "subscription_plan_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"user_subscription_active_idx": {
+					"name": "user_subscription_active_idx",
+					"columns": [
+						{
+							"expression": "active",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
 			"when": 1746830000927,
 			"tag": "0008_create-user-subscription",
 			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1748059458015,
+			"tag": "0009_add_curriculum_vitae_into_users",
+			"breakpoints": true
 		}
 	]
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"@ai-sdk/openai": "^1.3.21",
 		"@ai-sdk/react": "^1.2.11",
 		"@clerk/nextjs": "^6.18.5",
+		"@mistralai/mistralai": "^1.6.1",
 		"@neondatabase/serverless": "^1.0.0",
 		"@octokit/rest": "^21.1.1",
 		"@polar-sh/nextjs": "^0.4.0",

--- a/src/app/search/[slug]/query-users.ts
+++ b/src/app/search/[slug]/query-users.ts
@@ -137,6 +137,8 @@ export async function queryUsers(
 
 					createdAt: u.created_at,
 					updatedAt: u.updated_at,
+
+					curriculumVitae: u.curriculumVitae,
 				}) satisfies ScoredUserSelect,
 		)
 		.sort((a, b) => b.score - a.score);

--- a/src/app/search/advanced/[...params]/query-users.ts
+++ b/src/app/search/advanced/[...params]/query-users.ts
@@ -97,6 +97,7 @@ export async function queryUsersAdvanced(params: {
 					pinnedRepos: u.pinnedRepos,
 					createdAt: u.created_at,
 					updatedAt: u.updated_at,
+					curriculumVitae: u.curriculumVitae,
 				}) satisfies ScoredUserSelect,
 		)
 		.sort((a, b) => b.score - a.score);

--- a/src/db/schema/user.ts
+++ b/src/db/schema/user.ts
@@ -141,7 +141,7 @@ export const user = pgTable(
 		curriculumVitae: jsonb("curriculum_vitae")
 			.notNull()
 			.default(sql`'{}'::jsonb`)
-			.$type<CurriculumVitae[]>(),
+			.$type<CurriculumVitae>(),
 	},
 	(table) => [
 		// Individual column indexes - use GIN for arrays, B-tree for regular columns

--- a/src/db/schema/user.ts
+++ b/src/db/schema/user.ts
@@ -28,8 +28,64 @@ export const pinnedRepoSchema = z.object({
 	stars: z.number(),
 });
 
+export const curriculumVitaeSchema = z.object({
+	fullName: z.string().min(3),
+	email: z.string().email(),
+	phone: z.string().optional(),
+	location: z.string().optional(), // city, country
+	linkedin: z.string().url().optional(),
+	github: z.string().url().optional(),
+	portfolio: z.string().url().optional(),
+
+	summary: z.string().max(400).optional(),
+
+	experience: z.array(
+		z.object({
+			title: z.string(),
+			company: z.string(),
+			location: z.string().optional(),
+			startDate: z.string(), // ISO 8601 o "MMM YYYY"
+			endDate: z.string().optional(), // "Present" o "MMM YYYY"
+			descriptions: z.array(z.string()).optional(), // ej. as a list of bullet points
+			keywords: z.array(z.string()).optional(), // ej. ['React', 'TypeScript']
+		}),
+	),
+
+	education: z.array(
+		z.object({
+			degree: z.string(),
+			institution: z.string(),
+			location: z.string().optional(),
+			graduationYear: z.string().length(4),
+		}),
+	),
+
+	skills: z.array(z.string()),
+
+	certifications: z
+		.array(
+			z.object({
+				name: z.string(),
+				year: z.string().length(4),
+			}),
+		)
+		.optional(),
+
+	projects: z
+		.array(
+			z.object({
+				name: z.string(),
+				description: z.string().max(300),
+				techStack: z.array(z.string()).optional(),
+				link: z.string().url().optional(),
+			}),
+		)
+		.optional(),
+});
+
 export type Repo = z.infer<typeof repoSchema>;
 export type PinnedRepo = z.infer<typeof pinnedRepoSchema>;
+export type CurriculumVitae = z.infer<typeof curriculumVitaeSchema>;
 
 export const user = pgTable(
 	"user",
@@ -81,6 +137,11 @@ export const user = pgTable(
 			.notNull()
 			.default([])
 			.$type<PinnedRepo[]>(),
+
+		curriculumVitae: jsonb("curriculum_vitae")
+			.notNull()
+			.default(sql`'{}'::jsonb`)
+			.$type<CurriculumVitae[]>(),
 	},
 	(table) => [
 		// Individual column indexes - use GIN for arrays, B-tree for regular columns


### PR DESCRIPTION
### Summary

This pull request adds a new `curriculum_vitae` field to the `users` table in the database. This field allows us to store structured CV/resume data directly within a user's profile.

### Details

The `curriculum_vitae` field is designed to hold a rich set of user-provided information, including:

* **Personal details** such as full name, email, phone, location, and relevant links (LinkedIn, GitHub, portfolio).
* **Professional summary** with a brief personal description.
* **Experience history**, including job titles, companies, locations, durations, bullet-point descriptions, and relevant keywords.
* **Educational background**, covering degrees, institutions, and graduation years.
* **Skills list** as a simple array of key abilities.
* **Certifications** with names and years (optional).
* **Projects**, including descriptions, tech stacks, and external links (optional).

This field is stored as a JSONB column in PostgreSQL, which allows for flexible structure while maintaining query capabilities.


### Notes

* The change is backward-compatible.


closes GIT-52
closes #95 

