### PR TITLE
feat: add optional clerkId to user schema and update GitHub user task

### DIFF
--- a/.env0/config.json
+++ b/.env0/config.json
@@ -1,0 +1,4 @@
+{
+	"appName": "crafter-station/githunter",
+	"ownerName": "cuevaio"
+}

--- a/src/db/schema/user/index.ts
+++ b/src/db/schema/user/index.ts
@@ -112,6 +112,7 @@ export const user = pgTable(
 
 export const UserInsertSchema = z.object({
 	id: z.string(),
+	clerkId: z.string().optional(),
 
 	username: z.string(),
 	fullname: z.string(),

--- a/src/triggers/index-github-user-task.ts
+++ b/src/triggers/index-github-user-task.ts
@@ -39,6 +39,7 @@ export const indexGithubUserTask = schemaTask({
 
 		const userRecord: UserInsert = {
 			id: nanoid(),
+			clerkId: userId,
 			username,
 			fullname: userInfo.name ?? "",
 			avatarUrl: userInfo.avatarUrl,


### PR DESCRIPTION
## Summary
Adds optional clerkId field to user schema and updates the GitHub user indexing task to properly save clerkId when ingesting new authenticated users into the database.

## Changes
- ✅ Added optional `clerkId` field to the `UserInsertSchema` in the user schema
- ✅ Updated `indexGithubUserTask` to include clerkId when creating new user records from GitHub user data
- ✅ Ensures proper linking between authenticated users and database records

## Problem Solved
Previously, when new users registered through authentication, the ingestion task would create user records in our database but miss the clerkId field. This fix ensures that clerkId is properly captured and stored during user registration, maintaining proper user identity across the system.

## Testing
- [x] Verified schema changes don't break existing functionality
- [x] Tested user registration flow with clerkId being saved correctly
- [x] Confirmed existing users without clerkId remain unaffected

## Related
- Closes [GIT-69](https://linear.app/crafter-station/issue/GIT-69/fix-user-registration-task-to-save-clerkid-during-database-ingestion)