### PR TITLE
feat: add Clerk integration and implement case-insensitive username deduplication

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@ai-sdk/mistral": "^1.2.8",
         "@ai-sdk/openai": "^1.3.21",
         "@ai-sdk/react": "^1.2.11",
+        "@clerk/backend": "^1.33.0",
         "@clerk/nextjs": "^6.18.5",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/cook/populate-github-user.ts
+++ b/cook/populate-github-user.ts
@@ -1,7 +1,5 @@
 import { db } from "@/db";
-import { user as userTable } from "@/db/schema";
 import { PopulateGithubUser } from "@/services/populate-github-user.service";
-import { eq } from "drizzle-orm";
 
 if (require.main === module) {
 	(async () => {
@@ -25,7 +23,7 @@ if (require.main === module) {
 			}
 
 			const existingUser = await db.query.user.findFirst({
-				where: eq(userTable.username, username),
+				where: (table, { ilike }) => ilike(table.username, username),
 			});
 			if (existingUser) {
 				console.log(

--- a/cook/populate-github-users.ts
+++ b/cook/populate-github-users.ts
@@ -2,9 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as readline from "node:readline";
 import { db } from "@/db";
-import { user as userTable } from "@/db/schema";
 import { PopulateGithubUser } from "@/services/populate-github-user.service";
-import { eq } from "drizzle-orm";
 
 async function main() {
 	const filePath = path.resolve(__dirname, "../users.txt");
@@ -25,7 +23,7 @@ async function main() {
 		const [country, username, _] = line.split(",");
 		try {
 			const existingUser = await db.query.user.findFirst({
-				where: eq(userTable.username, username),
+				where: (table, { ilike }) => ilike(table.username, username),
 			});
 			if (existingUser) {
 				console.log(

--- a/cook/remove-users-duplicate-ilike-username.ts
+++ b/cook/remove-users-duplicate-ilike-username.ts
@@ -1,0 +1,51 @@
+import { db } from "@/db";
+import { user } from "@/db/schema";
+import { createClerkClient } from "@clerk/backend";
+import { eq, ilike } from "drizzle-orm";
+
+const clerk = createClerkClient({
+	secretKey: process.env.CLERK_SECRET_KEY,
+});
+
+export async function removeUsersDuplicateIlikeUsername() {
+	// Get all Clerk users
+	const clerkUsers = await clerk.users.getUserList({
+		limit: 100,
+	});
+
+	// For each Clerk user, try to find and update matching GitHub user
+	for (const clerkUser of clerkUsers.data) {
+		const githubUsername = clerkUser.username;
+
+		if (!githubUsername) {
+			continue;
+		}
+
+		// Update the user record with their Clerk ID
+		console.log(githubUsername);
+
+		const users = await db
+			.select({ username: user.username, id: user.id, clerkId: user.clerkId })
+			.from(user)
+			.where(ilike(user.username, githubUsername));
+
+		if (users.length > 1) {
+			// Find the user with exact lowercase match
+			const exactMatch = users.find(
+				(u) => u.username.toLowerCase() === githubUsername.toLowerCase(),
+			);
+
+			// Delete all other users
+			for (const u of users) {
+				if (u.id !== exactMatch?.id) {
+					await db.delete(user).where(eq(user.id, u.id));
+					console.log(`Deleted duplicate user: ${u.username}`);
+				}
+			}
+		}
+
+		console.log(users);
+	}
+}
+
+removeUsersDuplicateIlikeUsername();

--- a/cook/update-clerk-id.ts
+++ b/cook/update-clerk-id.ts
@@ -1,0 +1,38 @@
+import { db } from "@/db";
+import { user } from "@/db/schema";
+import { createClerkClient } from "@clerk/backend";
+import { ilike } from "drizzle-orm";
+
+const clerk = createClerkClient({
+	secretKey: process.env.CLERK_SECRET_KEY,
+});
+
+export async function updateClerkIds() {
+	// Get all Clerk users
+	const clerkUsers = await clerk.users.getUserList({
+		limit: 100,
+	});
+
+	// For each Clerk user, try to find and update matching GitHub user
+	for (const clerkUser of clerkUsers.data) {
+		const githubUsername = clerkUser.username;
+
+		if (!githubUsername) {
+			continue;
+		}
+
+		// Update the user record with their Clerk ID
+		try {
+			await db
+				.update(user)
+				.set({
+					clerkId: clerkUser.id,
+				})
+				.where(ilike(user.username, githubUsername));
+		} catch (error) {
+			console.error(error);
+		}
+	}
+}
+
+updateClerkIds();

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"@ai-sdk/mistral": "^1.2.8",
 		"@ai-sdk/openai": "^1.3.21",
 		"@ai-sdk/react": "^1.2.11",
+		"@clerk/backend": "^1.33.0",
 		"@clerk/nextjs": "^6.18.5",
 		"@dnd-kit/core": "^6.3.1",
 		"@dnd-kit/sortable": "^10.0.0",

--- a/src/app/api/og/users/[username]/route.tsx
+++ b/src/app/api/og/users/[username]/route.tsx
@@ -1,8 +1,6 @@
 import { db } from "@/db";
-import { user } from "@/db/schema";
 import { getTechIcon, getValidatedStack } from "@/lib/tech-icons";
 import { ImageResponse } from "@vercel/og";
-import { eq } from "drizzle-orm";
 import { notFound } from "next/navigation";
 import type { NextRequest } from "next/server";
 
@@ -15,7 +13,7 @@ export async function GET(
 	const { username } = await params;
 
 	const userData = await db.query.user.findFirst({
-		where: eq(user.username, username),
+		where: (table, { ilike }) => ilike(table.username, username),
 	});
 
 	if (!userData) {

--- a/src/app/developer/[username]/cv/page.tsx
+++ b/src/app/developer/[username]/cv/page.tsx
@@ -24,7 +24,7 @@ export default async function CVPreviewPage({
 			cv: userTable.curriculumVitae,
 		})
 		.from(userTable)
-		.where(ilike(userTable.username, `%${username}%`))
+		.where(ilike(userTable.username, username))
 		.limit(1);
 
 	if (!users.length) {

--- a/src/services/populate-github-user.service.ts
+++ b/src/services/populate-github-user.service.ts
@@ -79,7 +79,7 @@ export class PopulateGithubUser {
 		};
 
 		const existingUser = (await db.query.user.findFirst({
-			where: (table, { eq }) => eq(table.username, username),
+			where: (table, { ilike }) => ilike(table.username, username),
 		})) as UserSelect;
 		if (existingUser) {
 			userRecord.id = existingUser.id;

--- a/src/triggers/insert-user-to-db-task.ts
+++ b/src/triggers/insert-user-to-db-task.ts
@@ -8,7 +8,7 @@ export const insertUserToDbTask = schemaTask({
 	schema: UserInsertSchema,
 	run: async (user) => {
 		const existingUser = await db.query.user.findFirst({
-			where: (table, { eq }) => eq(table.username, user.username),
+			where: (table, { ilike }) => ilike(table.username, user.username),
 		});
 		if (existingUser) {
 			user.id = existingUser.id;


### PR DESCRIPTION
## Summary
Implements case-insensitive username matching across the application and adds Clerk integration for user management, including cleanup of duplicate users and clerkId migration.

## Changes
### Case-insensitive Username Matching
- ✅ Updated user queries across multiple files to use `ilike` function instead of `eq` for case-insensitive username matching
- ✅ Enhanced flexibility of username searches in the database

### Clerk Integration & User Management
- ✅ Added `@clerk/backend` dependency for Clerk integration
- ✅ Implemented `removeUsersDuplicateIlikeUsername` function to clean up duplicate users based on GitHub usernames
- ✅ Created `updateClerkIds` function to update existing user records with Clerk IDs by matching GitHub usernames

## Problem Solved
This PR addresses multiple user management issues:
1. **Case sensitivity**: Previously, usernames like "JohnDoe" and "johndoe" were treated as different users
2. **Duplicate users**: Existing duplicate usernames needed cleanup
3. **Missing clerkIds**: Existing users created before clerkId implementation needed to be migrated

## Testing
- [x] Verified case-insensitive username queries work correctly
- [x] Tested duplicate user removal function
- [x] Confirmed clerkId migration works for existing users
- [x] Ensured no data loss during cleanup operations

## Related
- Closes [GIT-71](https://linear.app/crafter-station/issue/GIT-71/migrate-existing-users-with-clerkid-and-implement-case-insensitive)
- Related to [GIT-69](https://linear.app/crafter-station/issue/GIT-69/fix-user-registration-task-to-save-clerkid-during-database-ingestion)