### PR TITLE
refactor: remove subscription check from CV upload action

### DIFF
--- a/src/actions/upload-cv.ts
+++ b/src/actions/upload-cv.ts
@@ -4,7 +4,6 @@ import { auth } from "@clerk/nextjs/server";
 import { tasks } from "@trigger.dev/sdk/v3";
 import { z } from "zod";
 
-import { getSubscription } from "@/lib/get-suscription";
 import type { processCurriculumVitaeTask } from "@/triggers/process-curriculum-vitae-task";
 
 const formSchema = z.object({
@@ -15,16 +14,7 @@ export async function uploadCVAction(
 	prevState: { error: string | null },
 	formData: FormData,
 ) {
-	const currentPlan = await getSubscription();
 	const session = await auth();
-
-	if (!currentPlan) {
-		return { error: "Unauthorized" };
-	}
-
-	if (currentPlan?.name !== "Plus") {
-		return { error: "Unauthorized" };
-	}
 
 	if (!session.userId) {
 		return { error: "Unauthorized" };


### PR DESCRIPTION
## Summary
Removes subscription validation from CV upload functionality, allowing all authenticated users to upload their CVs regardless of subscription tier.

## Changes
- ✅ Eliminated subscription validation logic from the `uploadCVAction` function
- ✅ Simplified authorization process by retaining only user session check
- ✅ Streamlined CV upload process to focus on user authentication rather than subscription status

## Problem Solved
Previously, CV upload functionality was restricted to PLUS subscribers only, which limited platform accessibility and user adoption. This change democratizes the CV feature, allowing all users to showcase their profiles and engage with the platform before considering paid subscriptions.

## Impact
- **Improved User Experience**: All authenticated users can now upload and manage their CVs
- **Increased Accessibility**: Removes paywall barrier for core CV functionality
- **Enhanced Onboarding**: New users can immediately benefit from CV features
- **Simplified Logic**: Cleaner authorization flow focused on authentication

## Testing
- [x] Verified free users can successfully upload CVs
- [x] Confirmed existing PLUS users continue to work normally
- [x] Tested that unauthenticated users are still properly blocked
- [x] Validated complete CV upload workflow for all user tiers

## Related
- Closes [GIT-72](https://linear.app/crafter-station/issue/GIT-72/enable-cv-upload-functionality-for-free-users)
- Related to CV upload functionality improvements